### PR TITLE
:bug: Fix default isAcitve state

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,7 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
 
 export default function App({ Component, pageProps }: AppProps) {
   const [isActiveMockWorker, setIsActiveMockWorker] = useState(
-    process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
+    process.env.NEXT_PUBLIC_API_MOCKING === "enabled" ? false : true
   );
 
   const { setIsMobile } = useSetIsMobile();


### PR DESCRIPTION
- Close #76 

## 概要

Mockを有効にしたい時は、最初はisActiveMockWorkerの値をfalseにしておいて、有効化されたらtrueにするようにしました