### PR TITLE
:art: Keep the aspect ratio of the image

### DIFF
--- a/components/orgs/OrgCard.tsx
+++ b/components/orgs/OrgCard.tsx
@@ -58,6 +58,7 @@ const orgImageStyle = css`
   height: 4.8rem;
   background-color: #eee;
   border-radius: 1.6rem;
+  object-fit: contain;
 `;
 
 const textBoxStyle = css`


### PR DESCRIPTION
- Close #94 

## 概要

`object-fit: contain;` をセットして、ロゴのアスペクト比が壊れないようにしました