### PR TITLE
:+1: Height to be the same in all devices

### DIFF
--- a/components/orgs/OrgCard.tsx
+++ b/components/orgs/OrgCard.tsx
@@ -93,6 +93,7 @@ const textContentPStyle = (theme: Theme) => css`
   overflow: hidden;
   font-family: GenShinGothicP, sans-serif;
   font-size: 1.2rem;
+  line-height: 1.8rem;
   color: ${theme.colors.orgCard.normalTextColor};
   text-align: left;
   word-break: break-all;


### PR DESCRIPTION
- Close #123 

## 概要

デバイスごとに行の高さが違ったことで #123 の問題が発生していました。line-heightを設定したので、全デバイスで同じ高さになると思います。
