### PR TITLE
:ambulance: Infinite redirect when uid provided

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -79,7 +79,7 @@ export default function Home({
   orgs,
   questions,
 }: HomeProps) {
-  const { replace } = useRouter();
+  const { replace, query } = useRouter();
   const { isMobile } = useIsMobile();
   // TODO: 相性診断するときにユーザ情報を作成すれば良いので、ここでユーザ情報を作成する必要はない
   useUser();
@@ -129,7 +129,7 @@ export default function Home({
 
   React.useEffect(() => {
     // uidのクエリパラメータ付きはOGP用URLなので、ホームにリダイレクトする
-    if (uid) {
+    if (query["uid"]) {
       // pushだとquery parameter付きURLが履歴に残るので、replaceを使う
       replace(
         "/",
@@ -137,7 +137,7 @@ export default function Home({
         { shallow: true } // URLだけ変更してページ内容は更新しない
       );
     }
-  }, [uid, replace]);
+  }, [query, replace]);
 
   return (
     <OrganizationProvider value={orgs}>


### PR DESCRIPTION
getServerSidePropsのほうで得たuidがずっと維持されてしまうことでリダイレクトが無限に続くバグを修正