### PR TITLE
:bug: Recover saved seed number

### DIFF
--- a/hooks/cardSeed.ts
+++ b/hooks/cardSeed.ts
@@ -12,7 +12,7 @@ export default function useStampCardSeed() {
       } else {
         const random = new Random();
         const seed = random.next();
-
+        localStorage.setItem("seed", seed.toString());
         return { seed: seed };
       }
     },


### PR DESCRIPTION
## 概要

スタンプカードのスタンプ表示に利用しているランダムシードの値を保存し忘れていたため、毎回スタンプの表示が変わってしまっていたのを修正します