### PR TITLE
:bug: Fixed random only return 0 or 1

### DIFF
--- a/components/stampcard/Stamp.tsx
+++ b/components/stampcard/Stamp.tsx
@@ -62,13 +62,14 @@ const markVisitedStyle = (seed: number) => {
   const random = new Random(seed);
   const minRotate = -0.15;
   const maxRotate = 0.15;
-  const rotate = random.nextNumber(0, 1) * (maxRotate - minRotate) + minRotate;
+  const rotate =
+    random.nextNumber(0, 10) * 0.1 * (maxRotate - minRotate) + minRotate;
   const maxMove = "5%";
 
   return css`
     position: absolute;
-    right: calc(${maxMove} * ${random.nextNumber(0, 1)});
-    bottom: calc(${maxMove} * ${random.nextNumber(0, 1)});
+    right: calc(${maxMove} * ${random.nextNumber(0, 10) * 0.1});
+    bottom: calc(${maxMove} * ${random.nextNumber(0, 10) * 0.1});
     z-index: 2;
     width: 30%;
     height: auto;


### PR DESCRIPTION
## 概要

`random.nextNumber`は整数値しか返さないので、0か1しか返していませんでしたが、ここは0.0~1.0の小数を返してくれるのを想定していました。
意図通りの挙動になるように修正しました。