### PR TITLE
:bug: Fix logo object-fit

### DIFF
--- a/components/visited/VisitedCard.tsx
+++ b/components/visited/VisitedCard.tsx
@@ -79,7 +79,7 @@ const logoContainer = (logoFocus: boolean) => css`
     position: absolute;
     width: 100%;
     height: 100%;
-    object-fit: ${logoFocus ? "contain" : "cover"};
+    object-fit: ${logoFocus ? "cover" : "contain"};
     border-radius: 10px;
   }
 `;


### PR DESCRIPTION
## 概要

訪問記録ページで、一部団体ロゴが枠内におさまっていませんでした。
logoFocusが付いている団体ロゴに対して、object-fitの値を付け間違えていたので修正しました。